### PR TITLE
Feature/urgent

### DIFF
--- a/macmo/Sources/domain/model/Memo.swift
+++ b/macmo/Sources/domain/model/Memo.swift
@@ -15,6 +15,12 @@ public struct Memo: Equatable {
     public var done: Bool
     public let createdAt: Date
     public let updatedAt: Date
+    
+    public var isUrgent: Bool {
+        // Consider urgent if due within 3 days (259200 seconds) and not completed
+        guard let due = due, !done else { return false }
+        return due.timeIntervalSinceNow <= 259200
+    }
 
     public init(
         id: String = UUID().uuidString,

--- a/macmo/Sources/presentation/components/MemoRowView.swift
+++ b/macmo/Sources/presentation/components/MemoRowView.swift
@@ -19,6 +19,17 @@ struct MemoRowView: View {
 
                 Spacer()
 
+                if memo.isUrgent {
+                    Text("URGENT")
+                        .font(.caption2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.red)
+                        .cornerRadius(4)
+                }
+
                 if memo.done {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundColor(.green)

--- a/macmo/Sources/service/dao/MemoDAO.swift
+++ b/macmo/Sources/service/dao/MemoDAO.swift
@@ -153,7 +153,6 @@ class MemoDAO: MemoDAOProtocol {
                 let now = Date()
                 let timeInterval = dueDate.timeIntervalSince(now)
                 // Consider urgent if due within 3 days (259200 seconds) and not completed
-//                urgentMatch = timeInterval > 0 && timeInterval <= 259200
                 urgentMatch = timeInterval <= 259200
             }
 


### PR DESCRIPTION
  Summary

  • Added urgent memo detection and visual indicator for time-sensitive tasks
  • Memos with due dates within 3 days are automatically marked as urgent
  • Added prominent urgent badge in memo list view

  Changes

  - Memo.swift: Implemented isUrgent computed property that returns true for incomplete memos due within 3 days
  - MemoRowView.swift: Added red "URGENT" badge that displays next to urgent memos in the list

  Technical Details

  - Urgent detection logic: due date ≤ 3 days from now AND not completed
  - Badge styling: Red background with white text, compact rounded design
  - Badge positioning: Appears before the completion checkmark in the top row

  Benefits

  - Provides immediate visual feedback for time-sensitive memos
  - Helps users prioritize tasks approaching their deadlines
  - Maintains clean UI with conditional badge display
  - No impact on completed memos (urgent badge hidden when done)