### PR TITLE
v1.18.0: Mac 캘린더 뷰 실시간 업데이트 개선

### DIFF
--- a/Projects/App/Sources/app/EventBus.swift
+++ b/Projects/App/Sources/app/EventBus.swift
@@ -9,8 +9,8 @@ import Combine
 
 final class EventBus {
     static let shared = EventBus()
-    
-    let detailWindowDismissed = PassthroughSubject<Void, Never>()
-    
+
+    let macCalendarViewUpdateNeeded = PassthroughSubject<Void, Never>()
+
     private init() {}
 }

--- a/Projects/App/Sources/app/MacmoApp.swift
+++ b/Projects/App/Sources/app/MacmoApp.swift
@@ -100,7 +100,7 @@ struct MacmoApp: App {
                 }
                 .environmentObject(navigationManager)
                 .onDisappear {
-                    EventBus.shared.detailWindowDismissed.send()
+                    EventBus.shared.macCalendarViewUpdateNeeded.send()
                 }
         }
         .defaultSize(width: 600, height: 700)
@@ -112,7 +112,7 @@ struct MacmoApp: App {
                 }
                 .environmentObject(navigationManager)
                 .onDisappear {
-                    EventBus.shared.detailWindowDismissed.send()
+                    EventBus.shared.macCalendarViewUpdateNeeded.send()
                 }
         }
         .defaultSize(width: 600, height: 700)

--- a/Projects/App/Sources/features/calendar/grid/mac/month/MacMonthCalendarView.swift
+++ b/Projects/App/Sources/features/calendar/grid/mac/month/MacMonthCalendarView.swift
@@ -22,7 +22,7 @@ struct MacMonthCalendarView: View {
             model.drawEmptyCells()
             model.fetchData()
         }
-        .onReceive(EventBus.shared.detailWindowDismissed) {
+        .onReceive(EventBus.shared.macCalendarViewUpdateNeeded) {
             model.fetchData()
         }
     }

--- a/Projects/App/Sources/features/detail/MemoDetailViewModel.swift
+++ b/Projects/App/Sources/features/detail/MemoDetailViewModel.swift
@@ -136,6 +136,7 @@ final class MemoDetailViewModel: ObservableObject {
         memo = updatedMemo
         isEditing = false
         userPreferenceRepository.setMemoDraft(.init(title: ""))
+        EventBus.shared.macCalendarViewUpdateNeeded.send()
     }
 
     @MainActor
@@ -154,12 +155,14 @@ final class MemoDetailViewModel: ObservableObject {
         try await memoListViewModel.update(updatedMemo)
         memo = updatedMemo
         isDone = updatedMemo.done // Keep UI in sync
+        EventBus.shared.macCalendarViewUpdateNeeded.send()
     }
 
     @MainActor
     func delete() async throws {
         let currentMemo = memo
         try await memoListViewModel.delete(currentMemo.id)
+        EventBus.shared.macCalendarViewUpdateNeeded.send()
     }
 
     @objc private func updateMemoDrating() {
@@ -174,5 +177,6 @@ final class MemoDetailViewModel: ObservableObject {
             updatedAt: Date()
         )
         userPreferenceRepository.setMemoDraft(updatedMemo)
+        EventBus.shared.macCalendarViewUpdateNeeded.send()
     }
 }


### PR DESCRIPTION
## Summary
- EventBus 이벤트명을 `detailWindowDismissed` → `macCalendarViewUpdateNeeded`로 변경하여 의미 명확화
- MemoDetailViewModel에서 메모 저장/수정/삭제/임시저장 시 캘린더 뷰 업데이트 이벤트 발송 추가
- 버전 1.18.0 (빌드 26)으로 업데이트

## Changes
- `Projects/App/Project.swift`: 버전 1.17.0 → 1.18.0, 빌드 25 → 26
- `Projects/App/Sources/app/EventBus.swift`: 이벤트명 리네이밍
- `Projects/App/Sources/app/MacmoApp.swift`: 새 이벤트명 적용
- `Projects/App/Sources/features/calendar/grid/mac/month/MacMonthCalendarView.swift`: 새 이벤트명 적용
- `Projects/App/Sources/features/detail/MemoDetailViewModel.swift`: 메모 변경 시 캘린더 업데이트 이벤트 발송

## Test plan
- [x] 메모 생성 후 캘린더 뷰에 즉시 반영되는지 확인
- [x] 메모 수정 후 캘린더 뷰에 즉시 반영되는지 확인
- [x] 메모 삭제 후 캘린더 뷰에 즉시 반영되는지 확인
- [x] 메모 완료 상태 토글 시 캘린더 뷰에 즉시 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)